### PR TITLE
Client can now GET user details from server

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -15,6 +15,7 @@ from views import (
     get_current_user_posts,
     delete_post,
     get_all_users,
+    get_user_detail,
 )
 
 
@@ -47,6 +48,9 @@ class JSONServer(HandleRequests):
                 "", status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value
             )
         elif url["requested_resource"] == "users":
+            if url["pk"] != 0:
+                response_body = get_user_detail(url["pk"])
+                return self.response(response_body, status.HTTP_200_SUCCESS.value)
             response_body = get_all_users()
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
         else:

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,4 @@
-from .user import create_user, login_user, get_all_users
+from .user import create_user, login_user, get_all_users, get_user_detail
 from .post import (
     view_all_posts,
     view_post_detail,

--- a/views/user.py
+++ b/views/user.py
@@ -99,3 +99,31 @@ def get_all_users():
 
         serialized_results = json.dumps(sorted_results)
     return serialized_results
+
+
+def get_user_detail(pk):
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+        SELECT 
+            u.id,
+            u.first_name,
+            u.last_name,
+            u.email,
+            u.bio,
+            u.username,
+            u.profile_image_url,
+            u.created_on
+        FROM Users u
+        WHERE u.id = ?
+        """,
+            (pk,),
+        )
+
+        query_result = db_cursor.fetchone()
+        dictionary_version = dict(query_result)
+        serialized_result = json.dumps(dictionary_version)
+    return serialized_result


### PR DESCRIPTION
# Why and What?
Client should be able to access information about a specific user. Server now listens for a GET request to the users/{userId} endpoint and returns relevant information.

# How?
- In json-server added a new endpoint to listen for a specific primary key on the /users endpoint.
- Added a new get_user_detail method in the user package. The method uses the primary key to find the proper row from the Users table. The row is returned , converted to a dictionary, and then serialized into a JSON string and passed back to the client. 

# Test:
- Using POSTMAN:
- Make a GET request to http://localhost:8088/users/1
- Did you get a response? 
- Did it include the id, first_name, last_name, email, bio, username, profile_image_url, and created_on data?