### PR TITLE
added delete_comment

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -21,6 +21,7 @@ from views import (
     create_subscription,
     create_comment,
     delete_subscription,
+    delete_comment
 )
 
 
@@ -161,6 +162,11 @@ class JSONServer(HandleRequests):
                         "Delete Successful",
                         status.HTTP_200_SUCCESS.value,
                     )
+        elif url["requested_resource"] == "comments":
+            if pk != 0:
+                successfully_deleted = delete_comment(pk)
+                if successfully_deleted:
+                    return self.response("Delete Successful", status.HTTP_200_SUCCESS.value)
 
 
 def main():

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -9,7 +9,7 @@ from .post import (
 )
 from .tag import view_all_tags, create_tag
 from .category import view_all_categories, create_category
-from .comments import view_post_comments, create_comment
+from .comments import view_post_comments, create_comment, delete_comment
 from .subscriptions import (
     create_subscription,
     view_follower_subscriptions,

--- a/views/comments.py
+++ b/views/comments.py
@@ -49,3 +49,16 @@ def create_comment(comment_data):
         )
 
     return True if db_cursor.rowcount > 0 else False
+
+def delete_comment(pk):
+    with sqlite3.connect("./db.sqlite3") as conn:
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            DELETE FROM Comments WHERE id = ?
+            """,
+            (pk,),
+        )
+
+    return True if db_cursor.rowcount > 0 else False


### PR DESCRIPTION
What?
Post comments can now be deleted only by the author of the comment.

Why?
Users can now add comments to posts and delete them, but are prevented from deleting other user's comments.

How?
This involved adding a `delete_comment` function to `comments.py` module, and adding a `do_DELETE` elif to listen for "comments".

Testing?
In Postman, enter `http://localhost:8088/comments/{commentId}` and send a DELETE request. You should get a 200 response and the comment with the entered id should be deleted from the database.